### PR TITLE
mbox 설정 및 메모생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,29 @@
+import { observer } from 'mobx-react';
 import Memo from './Memo/Memo';
+import AddIcon from '@mui/icons-material/Add';
+import { useCallback } from 'react';
 
-function App() {
+function App({ store }) {
+  const AddMemo = useCallback(() => store.addMemo(), [store]);
   return (
     <div>
-      <Memo />
+      {store.memos.map((item) => (
+        <Memo key={item.id} />
+      ))}
+
+      <AddIcon
+        sx={{
+          float: 'right',
+          backgroundColor: '#e4e4e4',
+          borderRadius: '5px',
+          cursor: 'pointer',
+          fontSize: '30px',
+          border: '1px solid black',
+        }}
+        onClick={AddMemo}
+      />
     </div>
   );
 }
 
-export default App;
+export default observer(App);

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,13 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import MemoStore from './store/memoStore';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <App store={new MemoStore()} />
+  </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/store/memoStore.js
+++ b/src/store/memoStore.js
@@ -1,0 +1,32 @@
+import { action, makeObservable, observable } from 'mobx';
+import { v1 as uuidv1 } from 'uuid';
+export class MemoModel {
+  id = uuidv1();
+  content = '';
+  x = 0;
+  y = 0;
+  width = 250;
+  height = 300;
+  constructor() {
+    makeObservable(this, {
+      content: observable,
+      x: observable,
+      y: observable,
+      width: observable,
+      height: observable,
+    });
+  }
+}
+
+export default class MemoStore {
+  memos = [];
+  constructor() {
+    makeObservable(this, {
+      memos: observable,
+      addMemo: action,
+    });
+  }
+  addMemo() {
+    this.memos.push(new MemoModel());
+  }
+}


### PR DESCRIPTION
mobx를 설정해서 메모 생성 기능을 구현함 

* store 폴더와 함께 `memoStore`를 생성해서 메모지 하나의 기본 모델인 `MemoModel`, 비어있는 `memos`에 ` `MemoModel`을 추가하는 `addMemo`이벤트를 작성함

* `index`에서 `App`에 `store` prop을 추가하고,  `App`에서 `memos`의 항목 수 만큼 `Memo` 컴포넌트를 렌더링하게 설정함

* 이 때, `AddIcon`을 추가해서 클릭하면 `AddMemo`라는 이벤트를 발생시켜서 메모지가 추가로 생성된다.