### PR TITLE
localstorage 연동

### DIFF
--- a/src/Memo/Memo.jsx
+++ b/src/Memo/Memo.jsx
@@ -50,10 +50,15 @@ const Memo = ({ item, Edit, setWidthHeight, setPosition, Delete }) => {
 
   const onClickDelete = useCallback(() => Delete(item.id), [Delete, item.id]);
   return (
-    <Draggable handleRef={handleRef} x={0} y={0} onMove={onChangePosition}>
+    <Draggable
+      handleRef={handleRef}
+      x={item.x}
+      y={item.y}
+      onMove={onChangePosition}
+    >
       <div
         className="memo-container"
-        style={{ width: `${250}px`, height: `${300}px` }}
+        style={{ width: `${item.width}px`, height: `${item.height}px` }}
         ref={memoContainer}
       >
         <div className="menu">

--- a/src/store/memoStore.js
+++ b/src/store/memoStore.js
@@ -1,4 +1,4 @@
-import { action, makeObservable, observable } from 'mobx';
+import { action, autorun, makeObservable, observable } from 'mobx';
 import { v1 as uuidv1 } from 'uuid';
 export class MemoModel {
   id = uuidv1();
@@ -19,6 +19,8 @@ export class MemoModel {
 }
 
 export default class MemoStore {
+  id = 'memoStore';
+  localStorage = null;
   memos = [];
   constructor() {
     makeObservable(this, {
@@ -28,6 +30,15 @@ export default class MemoStore {
       setWidthHeight: action,
       setPosition: action,
       removeMemo: action,
+      loadLocalStorage: action,
+    });
+
+    this.initLocalStorage();
+
+    autorun(() => {
+      if (this.localStorage !== null) {
+        this.localStorage.setItem(this.id, JSON.stringify(this.memos));
+      }
     });
   }
   addMemo() {
@@ -54,5 +65,19 @@ export default class MemoStore {
   }
   removeMemo(id) {
     this.memos.splice(this.getMemoIndex(id), 1);
+  }
+
+  initLocalStorage() {
+    if (window.localStorage[this.id] == null) {
+      this.localStorage = window.localStorage;
+      this.localStorage.setItem(this.id, JSON.stringify(this.memos.shift()));
+    } else {
+      this.localStorage = window.localStorage;
+      this.loadLocalStorage();
+    }
+  }
+
+  loadLocalStorage() {
+    this.memos = JSON.parse(this.localStorage.getItem(this.id));
   }
 }


### PR DESCRIPTION
`memoStore`에 localStorage를 생성하여 메모지가 추가될 때마다 `autorun`을 통해서 해당 데이터가 저장된다. 


* 이전에 기본 설정으로 지정한 x, y, width, height의 값들을 `item`에서 가져온 값으로 지정해서 재부팅을 해도 데이터들이 그대로 유지되게 함